### PR TITLE
Add losing message, store losing stats, and restarts game

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,11 +99,11 @@
             <th><input maxlength="1" onkeypress="return /[a-z]/i.test(event.key)" type="text" name="" value="" id="cell-5-24"></th>
           </tr>
           <tr id="row-6">
-            <th><input maxlength="1" onkeypress="return /[a-z]/i.test(event.key)" type="text" name="" value="" id="cell-5-25"></th>
-            <th><input maxlength="1" onkeypress="return /[a-z]/i.test(event.key)" type="text" name="" value="" id="cell-5-26"></th>
-            <th><input maxlength="1" onkeypress="return /[a-z]/i.test(event.key)" type="text" name="" value="" id="cell-5-27"></th>
-            <th><input maxlength="1" onkeypress="return /[a-z]/i.test(event.key)" type="text" name="" value="" id="cell-5-28"></th>
-            <th><input maxlength="1" onkeypress="return /[a-z]/i.test(event.key)" type="text" name="" value="" id="cell-5-29"></th>
+            <th><input maxlength="1" onkeypress="return /[a-z]/i.test(event.key)" type="text" name="" value="" id="cell-6-25"></th>
+            <th><input maxlength="1" onkeypress="return /[a-z]/i.test(event.key)" type="text" name="" value="" id="cell-6-26"></th>
+            <th><input maxlength="1" onkeypress="return /[a-z]/i.test(event.key)" type="text" name="" value="" id="cell-6-27"></th>
+            <th><input maxlength="1" onkeypress="return /[a-z]/i.test(event.key)" type="text" name="" value="" id="cell-6-28"></th>
+            <th><input maxlength="1" onkeypress="return /[a-z]/i.test(event.key)" type="text" name="" value="" id="cell-6-29"></th>
           </tr>
         </table>
         <div class="inline">
@@ -154,9 +154,13 @@
         <p class="informational-text">You've guessed the correct word <span id="stats-percent-correct">/some number/</span>% of the time.</p>
         <p class="informational-text">On average, it takes you <span id="stats-average-guesses">/some number/</span> guesses to find the correct word.</p>
       </section>
-      <section class="collapsed" id="game-over-section">
+      <section class="collapsed" id="winning-game-over-section">
         <h3 id="game-over-message">Yay!</h1>
-        <p class="informational-text">You did it! It took you <span id="game-over-guesses-count">/some number/</span> guess<span id="game-over-guesses-plural">es</span> to find the correct word.</p>
+        <p class="informational-text">You did it! It took you <span id="winning-game-over-guesses-count">/some number/</span> guess<span id="winning-game-over-guesses-plural">es</span> to find the correct word.</p>
+      </section>
+      <section class="collapsed" id="losing-game-over-section">
+        <h3 id="game-over-message">Boooo!</h1>
+        <p class="informational-text">You did not do it! It took you <span id="losing-game-over-guesses-count">/some number/</span> guess<span id="losing-game-over-guesses-plural">es</span> to still not find the correct word.</p>
       </section>
       <nav>
         <button type="button" name="play" class="nav-button active" id="play-button">play</button>
@@ -164,7 +168,6 @@
         <button type="button" name="rules" class="nav-button" id="stats-button">stats</button>
       </nav>
     </main>
-    <!-- <script src="words.js"></script> -->
     <script src="index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
# Description

Completes Iteration 2 - Game Over

Fixes:

A message appears on the screen letting the user know they have lost.
The message should disappear after 4 seconds.
The game board clears all previous guesses.
The focus is put back on the top left square of the game board (as it does on page load).
The key on the left side of the screen resets so all letters are black.
A new winning word is created.
The game stats should be stored in the gamesPlayed variable as { solved: false, guesses: 6 }

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Play through a game and intentionally lose to see the losing message. The events following is the same as the winning events, such as resetting the game, resetting the input focus, storing game stats, and randomizing a new winning word.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
